### PR TITLE
configのassetsを利用可能にするコマンド

### DIFF
--- a/app/commands/PochikaPublishAssetsCommand.php
+++ b/app/commands/PochikaPublishAssetsCommand.php
@@ -1,0 +1,82 @@
+<?php
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+class PochikaPublishAssetsCommand extends Command {
+
+	/**
+	 * The console command name.
+	 *
+	 * @var string
+	 */
+	protected $name = 'pochika:publish_assets';
+
+	/**
+	 * The console command description.
+	 *
+	 * @var string
+	 */
+	protected $description = 'Publish the pochika assets of theme.';
+
+	/**
+	 * Create a new command instance.
+	 *
+	 * @return void
+	 */
+	public function __construct()
+	{
+		parent::__construct();
+	}
+
+	/**
+	 * Execute the console command.
+	 *
+	 * @return void
+	 */
+	public function fire()
+	{
+        $configThemeName   = Conf::get('theme');
+		$sourceAssetPath   = sprintf("%s/source/themes/%s/assets", base_path(), $configThemeName);
+        $publishAssetPath  = sprintf("%s/assets", public_path());
+
+        if (file_exists($sourceAssetPath) && is_dir($sourceAssetPath))
+        {
+    		unlink($publishAssetPath);
+    		symlink($sourceAssetPath, $publishAssetPath);
+        }
+        else
+        {
+            throw new \Pochika\Exception\NotFoundException(
+                sprintf("theme[%s] could not found.", $configThemeName));
+        }
+
+        $this->info(sprintf("theme[%s] published!", $configThemeName));
+	}
+
+	/**
+	 * Get the console command arguments.
+	 *
+	 * @return array
+	 */
+	protected function getArguments()
+	{
+		return array(
+//			array('example', InputArgument::REQUIRED, 'An example argument.'),
+		);
+	}
+
+	/**
+	 * Get the console command options.
+	 *
+	 * @return array
+	 */
+	protected function getOptions()
+	{
+		return array(
+//			array('example', null, InputOption::VALUE_OPTIONAL, 'An example option.', null),
+		);
+	}
+
+}

--- a/app/start/artisan.php
+++ b/app/start/artisan.php
@@ -13,3 +13,4 @@
 
 Artisan::add(new PochikaClearCacheCommand);
 Artisan::add(new PochikaNewPostCommand);
+Artisan::add(new PochikaPublishAssetsCommand);

--- a/app/tests/PochikaPublishAssetsCommandTest.php
+++ b/app/tests/PochikaPublishAssetsCommandTest.php
@@ -1,0 +1,48 @@
+<?php
+
+class PochikaPublishAssetsCommandTest extends TestCase {
+
+    protected $dummyAssetsPath;
+
+    public function setUp()
+    {
+        $this->dummyAssetsPath = sprintf("%s/source/themes/dummy/assets", base_path());
+        $this->cleanUp();
+    }
+
+    public function tearDown()
+    {
+        $this->cleanUp();
+    }
+
+    public function testPublishAssets()
+    {
+        mkdir($this->dummyAssetsPath, 0777, true);
+        Conf::set('theme', 'dummy');
+
+        Artisan::call('pochika:publish_assets');
+
+        $assetsPath = sprintf("%s/public/assets", base_path());
+        $check = readlink($assetsPath);
+
+        $this->assertThat($check, $this->equalTo($this->dummyAssetsPath));
+    }
+
+    /**
+     * @expectedException Pochika\Exception\NotFoundException
+     */
+    public function testUnknownAssets()
+    {
+        Conf::set('theme', 'unknown');
+        Artisan::call('pochika:publish_assets');
+    }
+
+    protected function cleanUp()
+    {
+        if (file_exists($this->dummyAssetsPath)) {
+            rmdir($this->dummyAssetsPath);
+        }
+    }
+
+
+}


### PR DESCRIPTION
独自テーマ利用時にassetsがpublicに固定でsymbolic linkが貼られているため手動で切り替えが必要でした
なので、コマンド作成してconifgから利用するテーマを取得してlinkの張替えを出来るようにしました
