### PR TITLE
fix timezone and mono template header

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -41,7 +41,7 @@ return array(
 
 //	'timezone' => 'UTC',
 //  'timezone' => ini_get('date.timezone') ?: 'UTC',
-    'timezone' => 'asia/tokyo',
+    'timezone' => 'Asia/Tokyo',
 
 	/*
 	|--------------------------------------------------------------------------

--- a/source/themes/mono/inc/header.html
+++ b/source/themes/mono/inc/header.html
@@ -1,6 +1,6 @@
 <header role="banner">
 
-  <h1><a href="{{ site.url }}" data-pjax>{{ site.title }}</a></h1>
+  <h1><a href="{{ url('/') }}" data-pjax>{{ site.title }}</a></h1>
 
   <div class="subtitle">
     {{ site.subtitle }}
@@ -10,8 +10,8 @@
     <ul data-pjax>
       <li><a data-pjax href="{{ url('/') }}">Blog</a></li>
       <li><a data-pjax href="{{ url('about') }}">About</a></li>
-      <li><a href="/archives">Archives</a></li>
-      <li><a href="/search">Search</a></li>
+      <li><a href="{{ url('archives') }}">Archives</a></li>
+      <li><a href="{{ url('search') }}">Search</a></li>
       <!--<li><a href="{{ url('projects') }}">Projects</a></li>-->
       <!--<li><a data-pjax href="/about">Pages</a></li>-->
     </ul>


### PR DESCRIPTION
1. composer install するときに timezone 指定が違って、autoload ファイルを作れませんよと怒られたので修正
2. インストール後、サブディレクトリに配置したら遷移先が違ったので修正
